### PR TITLE
exports the init function to initialize the Datadog tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ APM.addTags({ teamId: context.params.teamId }, APM.getRootSpanFromContext(contex
 APM.markAsError(new Error('I am not thrown'))
 ```
 
+## Initialization
+
+To configure the datadog tracer simply invoke the provided init method with the options you need. This needs to be done once somewhere in your index or main file.
+
+An example main.ts
+
+```TS
+import * as APM from '@gamechanger/datadog-apm';
+
+const dataDogOptions:TracerOptions = {... some options ...};
+
+APM.init(dataDogOptions)
+
+... rest of imports/code go here
+```
+
 ## Deploying
 
 All publishing is done through the CI pipeline.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './trace-decorator';
 export * from './util';
+export { init } from './tracer'


### PR DESCRIPTION
The index.ts does not export the function necessary to initialize the dd-tracer for the decorator.  This change simply adds that to the exports.