### PR TITLE
[418797] Update workflows from master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,12 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - 'v*' 
   pull_request:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR updates all GitHub workflow references from 'master' to 'main' to prepare for default branch migration.